### PR TITLE
Add Weapon spread + Fix bulletSpeed

### DIFF
--- a/src/main/java/com/grave/Game/Entities/Bullet.java
+++ b/src/main/java/com/grave/Game/Entities/Bullet.java
@@ -67,10 +67,14 @@ public class Bullet extends RigEntity {
             flyTimer.reset();
 
             Vector3f playerLoc = objectManager.getEntity(fireAction.shooterID).getPosition();
-            Vector3f direction = fireAction.targetPosition.subtract(playerLoc).normalize();
+            Vector3f targetPos = fireAction.targetPosition;
+            targetPos.setZ(0);
+
+            Vector3f direction = targetPos.subtract(playerLoc).normalize();
+
 
             objectManager.submitEntityAction(id, new MoveAction(playerLoc), false);
-            objectManager.submitEntityAction(id, new VelocityAction(direction.normalize().mult(fireAction.gun.getSpeed())), false);
+            objectManager.submitEntityAction(id, new VelocityAction(direction.mult(fireAction.gun.getSpeed())), false);
         }
     }
     

--- a/src/main/java/com/grave/Game/Entities/Bullet.java
+++ b/src/main/java/com/grave/Game/Entities/Bullet.java
@@ -9,9 +9,12 @@ import com.grave.Object.Actions.FireAction;
 import com.grave.Object.Actions.MoveAction;
 import com.grave.Object.Actions.VelocityAction;
 import com.jme3.bullet.collision.PhysicsCollisionObject;
+import com.jme3.math.Quaternion;
 import com.jme3.math.Vector3f;
 import com.jme3.scene.Mesh;
 import com.jme3.system.NanoTimer;
+
+import java.util.Random;
 
 public class Bullet extends RigEntity {
     private NanoTimer flyTimer = new NanoTimer();
@@ -72,11 +75,35 @@ public class Bullet extends RigEntity {
 
             Vector3f direction = targetPos.subtract(playerLoc).normalize();
 
+            float spreadAngle = randomSpread(fireAction.gun.getSpread());
+
+            Vector3f spreadVector = turnVector(direction, spreadAngle);
 
             objectManager.submitEntityAction(id, new MoveAction(playerLoc), false);
-            objectManager.submitEntityAction(id, new VelocityAction(direction.mult(fireAction.gun.getSpeed())), false);
+            objectManager.submitEntityAction(id, new VelocityAction(spreadVector.mult(fireAction.gun.getSpeed())), false);
         }
     }
+
+    private float randomSpread(float spread){
+        System.out.println(spread);
+        Random random = new Random();
+        float min = -spread;
+        float max = spread;
+        float randomFloatInRange = min + random.nextFloat() * (max - min);
+        System.out.println(randomFloatInRange);
+        return randomFloatInRange;
+    }
+
+    private Vector3f turnVector(Vector3f vector, float angle){
+        float radianAngle = (float) Math.toRadians(angle);
+        Vector3f rotationAxis = new Vector3f(0, 0, 1).normalize();
+        Quaternion quaternion = new Quaternion();
+        quaternion.fromAngleAxis(radianAngle, rotationAxis);
+        Vector3f rotatedVector = quaternion.mult(vector);
+
+        return rotatedVector;
+    }
+
     
     @Override
     public void onCollision(Uuid otherID)

--- a/src/main/java/com/grave/Game/Gun.java
+++ b/src/main/java/com/grave/Game/Gun.java
@@ -1,10 +1,10 @@
 package com.grave.Game;
 
 public enum Gun {
-    ASSAULT("Assault Riffle", 2.0f, 3500.0f, 3.0f, 3.0f, 20, 0.1f, 1, 0.0f),
-    ASSAULT2("Assault Riffle 2", 3f, 3100.0f, 4.0f, 4.0f, 25, 0.3f, 3, 0.1f),
-    MACHINE("Machinegun", 10.0f, 5500.0f, 5.0f, 10.0f, 150, 0.04f, 1, 0.0f),
-    PISTOLE("Pistole",10.0f,2000.0f,5.0f,1.0f,10,0.4f,1,0.0f);
+    ASSAULT("Assault Riffle", 2.0f, 32.0f, 3.0f, 3.0f, 20, 0.1f, 1, 0.0f),
+    ASSAULT2("Assault Riffle 2", 3f, 30f, 4.0f, 4.0f, 25, 0.3f, 3, 0.1f),
+    MACHINE("Machinegun", 10.0f, 40.0f, 5.0f, 10.0f, 150, 0.04f, 1, 0.0f),
+    PISTOLE("Pistole",10.0f,23.0f,5.0f,1.0f,10,0.4f,1,0.0f);
 
     private final String name;
     private final float mass;

--- a/src/main/java/com/grave/Game/Gun.java
+++ b/src/main/java/com/grave/Game/Gun.java
@@ -1,10 +1,10 @@
 package com.grave.Game;
 
 public enum Gun {
-    ASSAULT("Assault Riffle", 2.0f, 32.0f, 3.0f, 3.0f, 20, 0.1f, 1, 0.0f),
-    ASSAULT2("Assault Riffle 2", 3f, 30f, 4.0f, 4.0f, 25, 0.3f, 3, 0.1f),
-    MACHINE("Machinegun", 10.0f, 40.0f, 5.0f, 10.0f, 150, 0.04f, 1, 0.0f),
-    PISTOLE("Pistole",10.0f,23.0f,5.0f,1.0f,10,0.4f,1,0.0f);
+    ASSAULT("Assault Riffle", 2.0f, 34.0f, 3.0f, 3.0f, 20, 0.1f, 1, 0.0f, 10),
+    ASSAULT2("Assault Riffle 2", 3f, 30f, 4.0f, 4.0f, 25, 0.3f, 3, 0.1f, 7),
+    MACHINE("Machinegun", 10.0f, 40.0f, 5.0f, 10.0f, 150, 0.04f, 1, 0.0f, 24f),
+    PISTOLE("Pistole",10.0f,23.0f,5.0f,1.0f,10,0.4f,1,0.0f, 0);
 
     private final String name;
     private final float mass;
@@ -15,8 +15,9 @@ public enum Gun {
     private final float gap;
     private final int salvo;
     private final float sgap;
+    private final float spread;
 
-    Gun(String name, float mass, float speed, float time, float reload, int magazine, float gap, int salvo, float sgap) {
+    Gun(String name, float mass, float speed, float time, float reload, int magazine, float gap, int salvo, float sgap, float spread) {
         this.name = name;
         this.mass = mass;
         this.speed = speed;
@@ -26,6 +27,7 @@ public enum Gun {
         this.gap = gap;
         this.salvo = salvo;
         this.sgap = sgap;
+        this.spread = spread;
     }
 
     public String getName() {
@@ -62,5 +64,9 @@ public enum Gun {
 
     public float getSgap() {
         return sgap;
+    }
+
+    public float getSpread() {
+        return spread;
     }
 }

--- a/src/main/java/com/grave/Game/World.java
+++ b/src/main/java/com/grave/Game/World.java
@@ -38,9 +38,6 @@ public class World {
         zombies = new ArrayList<Uuid>();
         spawnTimer = new NanoTimer();
         waveTimer = new NanoTimer();
-
-        app_.setDisplayStatView(false);
-        app_.setDisplayFps(false);
     }
 
     public void init()

--- a/src/main/java/com/grave/Graveborn.java
+++ b/src/main/java/com/grave/Graveborn.java
@@ -46,6 +46,9 @@ public class Graveborn extends SimpleApplication {
         Graveborn app = new Graveborn(arguments);
         app.setSettings(settings);
         app.setShowSettings(false);
+        app.setDisplayStatView(false);
+        app.setDisplayFps(false);
+        app.setPauseOnLostFocus(false);
         app.start(context);
     }
 


### PR DESCRIPTION
- Fixed: Game no longer freezes when window is out of focus (important for running multiple games on same machine)
- Fixed: bulletSpeed vector incorrectly scaled with the distance between the mouse position and the player
- Added: Randomized bulletSpread for each weapon (e.g.: Gun.spread = 45 -> shooting vector is randomly rotated up to 45 degrees to the right or left)